### PR TITLE
Fix: handling for ISO topic keyword.  Added IsoTopicResolver to handle

### DIFF
--- a/harvester-api/src/main/java/org/opengeoportal/harvester/api/client/solr/SolrRecord.java
+++ b/harvester-api/src/main/java/org/opengeoportal/harvester/api/client/solr/SolrRecord.java
@@ -115,8 +115,8 @@ public class SolrRecord {
 	private Date contentDate;
 	@Field("FgdcText")
 	private String fgdcText;
-	@Field("ThemeKeywordsSynonymsIso")
-	private String topicCategory;
+	//@Field("ThemeKeywordsSynonymsIso")
+	//private String topicCategory;
 
 	/**
 	 * @return the layerId
@@ -566,7 +566,7 @@ public class SolrRecord {
 				+ this.maxY);
 		map.put("Originator", this.originator);
 		map.put("Publisher", this.publisher);
-		map.put("TopicCatetory", this.topicCategory);
+		//map.put("TopicCategory", this.topicCategory);
 		return map;
 	}
 
@@ -641,7 +641,7 @@ public class SolrRecord {
 		record.setDataType(metadata.getGeometryType().toString());
         record.setWorkspaceName(metadata.getWorkspaceName());
         record.setGeoreferenced(metadata.getGeoreferenced());
-		record.setTopicCategory(metadata.getTopic());
+		//record.setTopicCategory(metadata.getTopic());
 
         if (StringUtils.isNotEmpty(metadata.getLocation())) {
             record.setAvailability("online");
@@ -655,17 +655,17 @@ public class SolrRecord {
 	/**
 	 * @return the topicCategory
 	 */
-	public String getTopicCategory() {
+	/*public String getTopicCategory() {
 		return topicCategory;
-	}
+	}*/
 
 	/**
 	 * @param topicCategory
 	 *            the topicCategory to set
 	 */
-	public void setTopicCategory(String topicCategory) {
+	/*public void setTopicCategory(String topicCategory) {
 		this.topicCategory = topicCategory;
-	}
+	}*/
 
 	/**
 	 * @return the originalXmlMetadata

--- a/harvester-api/src/main/java/org/opengeoportal/harvester/api/metadata/model/GeometryType.java
+++ b/harvester-api/src/main/java/org/opengeoportal/harvester/api/metadata/model/GeometryType.java
@@ -38,8 +38,13 @@ public enum GeometryType {
                 return "";
             }
         }
+        
 		public static GeometryType parseGeometryType(String geometryString){
 			geometryString = geometryString.trim();
+			//legacy case
+			if (geometryString.equalsIgnoreCase("Paper Map")){
+				return GeometryType.ScannedMap;
+			}
 			for (GeometryType geomType : GeometryType.values()){
 				if (geomType.toString().equalsIgnoreCase(geometryString)){
 					return geomType;

--- a/harvester-api/src/main/java/org/opengeoportal/harvester/api/metadata/parser/IsoTopicResolver.java
+++ b/harvester-api/src/main/java/org/opengeoportal/harvester/api/metadata/parser/IsoTopicResolver.java
@@ -1,0 +1,31 @@
+package org.opengeoportal.harvester.api.metadata.parser;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class IsoTopicResolver {
+	HashSet<String> isoTopics;
+	
+	IsoTopicResolver(){
+		isoTopics = new HashSet<String>(Arrays.asList(new String[] {
+			"farming", "biota", "boundaries",
+			"climatologyMeteorologyAtmosphere", "economy", "elevation", "environment",
+			"imageryBaseMapsEarthCover", "intelligenceMilitary", "inlandWaters", "location",
+			"oceans", "planningCadastre", "society", "structure",
+			"transportation", "utilitiesCommunication",
+			"geoscientificInformation", "health" }));
+	}
+	
+	
+	public String getIsoTopicKeyword(String keyword){
+		for (String topic: isoTopics){
+			if (topic.equalsIgnoreCase(keyword.trim())){
+				return topic;
+			}
+		}
+		
+		return "";
+	};
+	
+	
+}


### PR DESCRIPTION
ISO topic keywords for FGDC and OGP metadata parsing.  Removed ISO topic
from the Solr record model, since the schema does not support it.

Also, fixed handling of scanned maps to report as "raster" type.
