### PR TITLE
Fix: Selecting “Geographic Extent” in the required fields section

### DIFF
--- a/harvester-api/src/main/java/org/opengeoportal/harvester/api/domain/IngestCsw.java
+++ b/harvester-api/src/main/java/org/opengeoportal/harvester/api/domain/IngestCsw.java
@@ -73,7 +73,7 @@ public class IngestCsw extends Ingest {
 		super();
 		validRequiredFields = new HashSet<String>(Arrays.asList(new String[] {
 				"geographicExtent", "themeKeyword", "placeKeyword", "topic",
-				"dateOfContent", "originator", "dataType", "dataRepository" }));
+				"dateOfContent", "originator", "dataType", "webServices" }));
 	}
 
 	public Date getDateFrom() {

--- a/harvester-api/src/main/java/org/opengeoportal/harvester/api/domain/IngestGeonetwork.java
+++ b/harvester-api/src/main/java/org/opengeoportal/harvester/api/domain/IngestGeonetwork.java
@@ -69,7 +69,7 @@ public class IngestGeonetwork extends Ingest {
 		super();
 		validRequiredFields = new HashSet<String>(Arrays.asList(new String[] {
 				"geographicExtent", "themeKeyword", "placeKeyword", "topic",
-				"dateOfContent", "originator", "dataType", "dataRepository" }));
+				"dateOfContent", "originator", "dataType", "webServices" }));
 	}
 
 	public String getTitle() {

--- a/harvester-api/src/main/java/org/opengeoportal/harvester/api/domain/IngestWebDav.java
+++ b/harvester-api/src/main/java/org/opengeoportal/harvester/api/domain/IngestWebDav.java
@@ -57,7 +57,7 @@ public class IngestWebDav extends Ingest {
 		super();
 		validRequiredFields = new HashSet<String>(Arrays.asList(new String[] {
 				"geographicExtent", "themeKeyword", "placeKeyword", "topic",
-				"dateOfContent", "originator", "dataType", "dataRepository" }));
+				"dateOfContent", "originator", "dataType", "webServices" }));
 	}
 
 	public Date getDateFrom() {

--- a/harvester-api/src/main/java/org/opengeoportal/harvester/api/metadata/parser/BaseMetadataParser.java
+++ b/harvester-api/src/main/java/org/opengeoportal/harvester/api/metadata/parser/BaseMetadataParser.java
@@ -79,10 +79,15 @@ public class BaseMetadataParser {
 
 	protected String buildLocationJsonFromLocationLinks(
 			Multimap<LocationType, LocationLink> linksMultimap) {
+		//dont' return an empty object
+		if (linksMultimap.isEmpty()){
+			return "";
+		}
+		
 		StringBuilder sb = new StringBuilder("{");
-
-		for (Iterator<LocationType> keyIterator = linksMultimap.keySet()
-				.iterator(); keyIterator.hasNext();) {
+		Iterator<LocationType> keyIterator = linksMultimap.keySet()
+				.iterator();
+		while (keyIterator.hasNext()) {
 			LocationType type = keyIterator.next();
 			boolean isArray = type.getIsArray();
 			sb.append("\"").append(type.toString()).append("\":");
@@ -114,5 +119,6 @@ public class BaseMetadataParser {
 		sb.append("}");
 
 		return sb.toString();
+
 	}
 }

--- a/web/src/main/webapp/WEB-INF/views/partial/csw.jsp
+++ b/web/src/main/webapp/WEB-INF/views/partial/csw.jsp
@@ -107,7 +107,7 @@
 
 		<div class="form-group col-md-9">
 			<label for="customCswQuery"><spring:message
-					code="ingestExternalRecords.form.custoCswQuery" /></label> <a href="#"
+					code="ingestExternalRecords.form.customCswQuery" /></label> <a href="#"
 				data-toggle="tooltip"
 				title='<spring:message code="ingestExternalRecords.tooltip.customCswQuery"/>'><span
 				class="glyphicon glyphicon-question-sign black"></span></a>

--- a/web/src/main/webapp/resources/locales/locale-en.json
+++ b/web/src/main/webapp/resources/locales/locale-en.json
@@ -25,7 +25,7 @@
 		"ADD_NAME_OGP_REPO_CANCEL_BUTTON": "Cancel",
 		"ADD_NAME_OGP_REPO_NAME_LABEL": "Name:",
 		"SOLR_SEARCH_CRITERIA": "Search criteria (optional)",
-		"SOLR_SEARCH_CRITERIA_TOOLTIP": "Please add the content of the tooltip for Sorl Search Criteria",
+		"SOLR_SEARCH_CRITERIA_TOOLTIP": "Please add the content of the tooltip for Solr Search Criteria",
 		"EXTENT": "Geographic Extent:",
 		"EXTENT_TOOLTIP": "Please add the content of the extent tooltip",
 		"THEME_KEYWORD": "Theme Keyword:",
@@ -74,12 +74,12 @@
 		"EXCLUDE_RESTRICTED_TOOLTIP": "Please add the content of Exclude Restricted tooltip",
 		"DATE_RANGE_SOLR": "Filter records by Solr timestamp:",
 		"DATE_RANGE_SOLR_TOOLTIP": "Please add the content of Date Range Solr tooltip",
-		"SOLR_CUSTOM_QUERY": "Custom Sorl Query:",
+		"SOLR_CUSTOM_QUERY": "Custom Solr Query:",
 		"SOLR_CUSTOM_QUERY_TOOLTIP": "Please add the content of the Custom SOLR Query Tooltip",
 
 		"REQUIRED_FIELDS": "OGP Required Fields (optional)",
 		"REQUIRED_FIELDS_TOOLTIP": "Please add the content of Required Fields tooltip",
-		"REQUIRED_FIELD_OPT_extent": "Geographic Extent",
+		"REQUIRED_FIELD_OPT_geographicExtent": "Geographic Extent",
 		"REQUIRED_FIELD_OPT_topic": "Topic",
 		"REQUIRED_FIELD_OPT_dataType": "Data Type",
 		"REQUIRED_FIELD_OPT_themeKeyword": "Theme Keyword",
@@ -143,9 +143,9 @@
         "ERROR_CONNECTING_TO_REMOTE_SOLR": "Cannot retrieve remote sources from this URL. Please check the URL.",
         "ERROR_RETRIEVING_REMOTE_SOURCES": "An internal error occurred while retrieving sources from the remote server. Please check the URL.",
         "ERROR_CONNECTING_TO_REMOTE_GEONETWORK": "Cannot retrieve remote sources from this URL. Please check the URL.",
-        "ERROR_CONNECTING_TO_PREDEFINED_GEONETWORK": "Cannot retrieve remote sources from the remote server. Please, contact with the admin.",
-        "ERROR_CONNECTING_TO_PREDEFINED_SOLR": "Cannot retrieve remote sources from the remote server. Please, contact with the admin.",
-        "ERROR_RETRIEVING_PREDEFINED_REMOTE_SOURCES": "An internal error occurred while retriving sources from the remote server. Please, contact with the admin."
+        "ERROR_CONNECTING_TO_PREDEFINED_GEONETWORK": "Cannot retrieve remote sources from the remote server. Please contact the admin.",
+        "ERROR_CONNECTING_TO_PREDEFINED_SOLR": "Cannot retrieve remote sources from the remote server. Please contact the admin.",
+        "ERROR_RETRIEVING_PREDEFINED_REMOTE_SOURCES": "An internal error occurred while retrieving sources from the remote server. Please contact the admin."
 
 	},
 
@@ -168,7 +168,7 @@
 		"CANCEL_UNSCHEDULE": "Cancel",
 		"STOP_INGEST_HEADER": "Cancel current execution",
 		"STOP_INGEST_HEADER_TOOLTIP": "This is the Stop Ingest dialog tooltip",
-		"STOP_INGEST_CONFIRM_TEXT": "You are about to discard current execution of this ingest. Records that have already been processed will be in OGP. Are you really sure you want to cancel execution?",
+		"STOP_INGEST_CONFIRM_TEXT": "You are about to discard current execution of this ingest. Records that have already been processed will be in OGP. Are you sure you want to cancel execution?",
 		"CONFIRM_STOP": "Stop",
 		"CANCEL_STOP": "Cancel",
         "ERROR_INTERRUPTING_INGEST": "An error has been found while stopping ingest.",
@@ -270,7 +270,7 @@
 	},
     "MAP": {
         "HEADER": "Geographic Extent",
-        "HEADER_TOOLTIP": "Select the geographic extent for the serch filter",
+        "HEADER_TOOLTIP": "Select the geographic extent for the search filter",
         "SELECT_EXTENT": "Select Current Geographic Extent",
         "SELECT_CANCEL": "Cancel"
     }

--- a/web/src/main/webapp/static/js/angularjs/controllers.js
+++ b/web/src/main/webapp/static/js/angularjs/controllers.js
@@ -836,18 +836,18 @@ var globalExtentMaxy;
 
             $scope.dataTypeList = ["POINT", "LINE", "POLYGON", "RASTER", "SCANNED"];
 
-
+    		
             $scope.requiredFieldList = {
-                SOLR: ["extent", "topic", "dataType", "themeKeyword", "dateOfContent", "dataRepository",
+                SOLR: ["geographicExtent", "topic", "dataType", "themeKeyword", "dateOfContent", "dataRepository",
                     "placeKeyword", "originator", "webServices"
                 ],
-                GEONETWORK: ["extent", "topic", "dataType", "themeKeyword", "dateOfContent", "dataRepository",
+                GEONETWORK: ["geographicExtent", "topic", "dataType", "themeKeyword", "dateOfContent", "webServices",
                     "placeKeyword", "originator"
                 ],
-                CSW: ["extent", "topic", "dataType", "themeKeyword", "dateOfContent", "dataRepository",
+                CSW: ["geographicExtent", "topic", "dataType", "themeKeyword", "dateOfContent", "webServices",
                     "placeKeyword", "originator"
                 ],
-                WEBDAV: ["extent", "topic", "dataType", "themeKeyword", "dateOfContent", "dataRepository",
+                WEBDAV: ["geographicExtent", "topic", "dataType", "themeKeyword", "dateOfContent", "webServices",
                     "placeKeyword", "originator"
                 ]
             };


### PR DESCRIPTION
doesn’t behave as expected.  On a harvest with “Geographic Extent” set
as a required field, all records showed as “passed” even though a large
number were missing bounds.  In Solr, the records show with bounds
[0,0,0,0].  When viewing ingest details to look at the query
terms/required terms after the ingest is complete, “Geographic Extent”
was unchecked. To fix, changed all instances of "extent" for required
fields to "geographicExtent".

Fix: "Web Services" required field didn't work, since MetadataValidator
just looks for an empty string and the code that creates the Location
json string always returns at least an empty object ("{}"). Changed the
code to return an empty string for an empty Location object.

Fix: typo in csw.jsp "ingestExternalRecords.form.custoCswQuery" to
"ingestExternalRecords.form.customCswQuery"

Change: “Web Services” is missing as a required field for all but the
OGP ingest.  “Data Repository” doesn’t make sense as a required field in
the non-OGP ingests, since the user must set the repository name.
Removed "Data Repository" as a required field and added "Web Services"
where appropriate.
